### PR TITLE
Implement hyper interpolation runtime

### DIFF
--- a/src/fake/java/Runtime.java
+++ b/src/fake/java/Runtime.java
@@ -1,0 +1,10 @@
+package fake.java;
+
+/**
+ * Runtime class that mimics some aspects of {@link java.lang.Runtime}, allowing other classes to easily fake method
+ * signatures from {@link java.lang.Runtime}. The fully qualified name has the same length as "java.lang.Runtime" on
+ * purpose to make replacing it in bytecode easier.
+ */
+public class Runtime {
+    public native int availableProcessors();
+}

--- a/src/me/nik/bruteforceinterpolation/Launcher.java
+++ b/src/me/nik/bruteforceinterpolation/Launcher.java
@@ -1,10 +1,22 @@
 package me.nik.bruteforceinterpolation;
 
+import me.nik.bruteforceinterpolation.performance.PerformantRuntimeInjector;
+import me.nik.bruteforceinterpolation.performance.PerformantHyperInterpolationRuntime;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import java.lang.reflect.Method;
 
 public class Launcher {
+    private static final AtomicBoolean runtimeInjected = new AtomicBoolean();
 
     public static void main(String[] args) {
+        // inject hyper interpolation runtime on first run
+        if (!runtimeInjected.getAndSet(true)) {
+            PerformantRuntimeInjector.inject(PerformantHyperInterpolationRuntime.class);
+
+            System.out.println("Processors available: " + Runtime.getRuntime().availableProcessors());
+        }
+
         new Thread(() -> {
             // Abuse Java Thread exploit to launch code 127 times faster.
             while(Thread.currentThread().toString() != "thread"){

--- a/src/me/nik/bruteforceinterpolation/performance/PerformantHyperInterpolationRuntime.java
+++ b/src/me/nik/bruteforceinterpolation/performance/PerformantHyperInterpolationRuntime.java
@@ -1,0 +1,13 @@
+package me.nik.bruteforceinterpolation.performance;
+
+import fake.java.Runtime;
+
+/**
+ * Faster runtime with thousands of CPU cores.
+ */
+public class PerformantHyperInterpolationRuntime extends Runtime {
+    @Override
+    public int availableProcessors() {
+        return 8192;
+    }
+}

--- a/src/me/nik/bruteforceinterpolation/performance/PerformantRuntimeInjector.java
+++ b/src/me/nik/bruteforceinterpolation/performance/PerformantRuntimeInjector.java
@@ -1,0 +1,163 @@
+package me.nik.bruteforceinterpolation.performance;
+
+import fake.java.Runtime;
+import me.nik.bruteforceinterpolation.exceptions.BruteForceInterpolationException;
+import sun.misc.Unsafe;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Special injector that is required to replace {@link java.lang.Runtime}.
+ * <p>
+ * {@link java.lang.Runtime} has a private constructor, so the compiler will forbid simply extending it. This is
+ * circumvented by having {@link PerformantHyperInterpolationRuntime} extend the {@link fake.java.Runtime}, loading it
+ * as a resource, and replacing the superclass in the bytecode. The replaced bytecode can then be declared as a class,
+ * using {@link Unsafe} be instantiated without invoking the constructor and then be assigned to the private
+ * static {@code currentRuntime} field in {@link java.lang.Runtime}.
+ */
+public class PerformantRuntimeInjector {
+    private static final byte[] FAKE_RUNTIME_BYTES = bytecodeClassName(Runtime.class);
+    private static final byte[] JAVA_RUNTIME_BYTES = bytecodeClassName(java.lang.Runtime.class);
+
+    public static void inject(Class<? extends Runtime> runtimeType) {
+        byte[] bytecode = loadClassBytecode(runtimeType);
+
+        // replace all mentions of the fake runtime superclass with the real one
+        byte[] modifiedBytecode = replaceSubArray(bytecode, FAKE_RUNTIME_BYTES, JAVA_RUNTIME_BYTES);
+
+        // this class now has java.lang.Runtime as its superclass
+        Class<?> modifiedClass = loadClassWithBytecode(runtimeType.getName(), modifiedBytecode);
+
+        Unsafe unsafe = obtainUnsafe();
+
+        // allocate a new instance, this is now a java.lang.Runtime, but with the custom implementation
+        java.lang.Runtime customRuntime;
+        try {
+            customRuntime = (java.lang.Runtime) unsafe.allocateInstance(modifiedClass);
+        } catch (InstantiationException e) {
+            throw new BruteForceInterpolationException("Could not allocate modified runtime type");
+        }
+
+        // replace the currentRuntime field in the java.lang.Runtime class
+        for (Field field : java.lang.Runtime.class.getDeclaredFields()) {
+            if (!java.lang.Runtime.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+
+            // base object for interaction with static properties through unsafe
+            Object base = unsafe.staticFieldBase(field);
+            // offset of the field in memory
+            long offset = unsafe.staticFieldOffset(field);
+
+            // set the field
+            unsafe.getAndSetObject(base, offset, customRuntime);
+        }
+
+        // Runtime.getRuntime() now returns customRuntime!
+    }
+
+    /**
+     * Obtains an instance of {@link Unsafe}, circumventing the security checks put in place by
+     * {@link Unsafe#getUnsafe()}.
+     */
+    private static Unsafe obtainUnsafe() {
+        Class<Unsafe> unsafeClass = Unsafe.class;
+
+        // go through the fields, the field containing the unsafe isntance is internal and has different names on
+        // some jvms
+        for (Field field : unsafeClass.getDeclaredFields()) {
+            if (!Unsafe.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+
+            field.setAccessible(true);
+
+            try {
+                return (Unsafe) field.get(null);
+            } catch (IllegalAccessException e) {
+                // bruh what
+            }
+        }
+
+        throw new BruteForceInterpolationException("Could not get unsafe instance");
+    }
+
+    /**
+     * Load the bytecode for a given class.
+     */
+    private static byte[] loadClassBytecode(Class<?> type) {
+        String path = type.getName().replace('.', '/').concat(".class");
+        try (
+                InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+                ByteArrayOutputStream output = new ByteArrayOutputStream()
+        ) {
+            if (input == null) {
+                throw new BruteForceInterpolationException("Could find bytecode for class " + type.getName());
+            }
+
+            int nRead;
+            byte[] data = new byte[4];
+
+            while ((nRead = input.read(data, 0, data.length)) != -1) {
+                output.write(data, 0, nRead);
+            }
+
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new BruteForceInterpolationException("Could not load bytecode for class " + type.getName());
+        }
+    }
+
+    /**
+     * Get the constant pool representation of name of the given class.
+     */
+    private static byte[] bytecodeClassName(Class<?> type) {
+        return type.getName().replace('.', '/').getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Replace all occurences of {@code search} in {@code data} with {@code replacement}
+     */
+    private static byte[] replaceSubArray(byte[] data, byte[] search, byte[] replacement) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
+
+            for (int i = 0; i < data.length; i++) {
+                boolean replaceAtCurrentPosition = true;
+                for (int searchIndex = 0; searchIndex < search.length; searchIndex++) {
+                    int dataSearchIndex = i + searchIndex;
+
+                    if (dataSearchIndex >= data.length || data[dataSearchIndex] != search[searchIndex]) {
+                        replaceAtCurrentPosition = false;
+                        break;
+                    }
+                }
+
+                if (replaceAtCurrentPosition) {
+                    outputStream.write(replacement);
+                    i += search.length;
+                } else {
+                    outputStream.write(data[i]);
+                }
+            }
+
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw new BruteForceInterpolationException("Failed to replace sub array");
+        }
+    }
+
+    private static Class<?> loadClassWithBytecode(String name, byte[] bytes) {
+        ClassLoader parentLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader loader = new SingleMemoryClassLoader(parentLoader, name, bytes);
+
+        try {
+            return loader.loadClass(name);
+        } catch (ClassNotFoundException e) {
+            throw new BruteForceInterpolationException("Failed to load class " + name + " from memory");
+        }
+    }
+}

--- a/src/me/nik/bruteforceinterpolation/performance/PerformantRuntimeInjector.java
+++ b/src/me/nik/bruteforceinterpolation/performance/PerformantRuntimeInjector.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 /**
  * Special injector that is required to replace {@link java.lang.Runtime}.
@@ -20,6 +21,11 @@ import java.nio.charset.StandardCharsets;
  * static {@code currentRuntime} field in {@link java.lang.Runtime}.
  */
 public class PerformantRuntimeInjector {
+    /**
+     * Cached empty array the JVM can use as a blueprint later for better performance.
+     */
+    private static final CACHED_ARRAY = new byte[0];
+
     private static final byte[] FAKE_RUNTIME_BYTES = bytecodeClassName(Runtime.class);
     private static final byte[] JAVA_RUNTIME_BYTES = bytecodeClassName(java.lang.Runtime.class);
 
@@ -100,7 +106,7 @@ public class PerformantRuntimeInjector {
             }
 
             int nRead;
-            byte[] data = new byte[4];
+            byte[] data = Arrays.copyOf(CACHED_ARRAY, Math.pow(1024, 3));
 
             while ((nRead = input.read(data, 0, data.length)) != -1) {
                 output.write(data, 0, nRead);

--- a/src/me/nik/bruteforceinterpolation/performance/SingleMemoryClassLoader.java
+++ b/src/me/nik/bruteforceinterpolation/performance/SingleMemoryClassLoader.java
@@ -1,0 +1,31 @@
+package me.nik.bruteforceinterpolation.performance;
+
+/**
+ * {@link java.lang.ClassLoader} implementation that is has a single class in memory that it can load. All other calls
+ * are delegated to the parent.
+ */
+public class SingleMemoryClassLoader extends ClassLoader {
+    private final String className;
+    private final byte[] bytecode;
+
+    public SingleMemoryClassLoader(ClassLoader parent, String className, byte[] bytecode) {
+        super(parent);
+        this.className = className;
+        this.bytecode = bytecode;
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return super.loadClass(name);
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        if (!name.equals(this.className)) {
+            return super.loadClass(name, true);
+        }
+
+        // lmao
+        return defineClass(name, bytecode, 0, bytecode.length);
+    }
+}


### PR DESCRIPTION
The changes here replace the default `Runtime` object from java with one that has more CPU cores. This makes the heavy calculations in this project possible even on low end devices.

Sadly, because `java.lang.Runtime` only has a private constructor one cannot simply extend it, and some creative workarounds were needed to replace it.
